### PR TITLE
Remove explicit path declaration for perl, use /usr/bin/env instead

### DIFF
--- a/font-size
+++ b/font-size
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # On-the-fly adjusting of the font size in urxvt
 #


### PR DESCRIPTION
For some operating systems perl isn't in /usr/bin, would suggest using this instead. Without it, this script doesn't work on operating systems like NixOS.