### PR TITLE
Update deprecated syntax.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -33,10 +33,10 @@ to the script to the `URxvt.perl-lib` resource.
 Add some keybindings:
 
 ```
-URxvt.keysym.C-Up:     perl:font-size:increase
-URxvt.keysym.C-Down:   perl:font-size:decrease
-URxvt.keysym.C-S-Up:   perl:font-size:incglobal
-URxvt.keysym.C-S-Down: perl:font-size:decglobal
+URxvt.keysym.C-Up:     font-size:increase
+URxvt.keysym.C-Down:   font-size:decrease
+URxvt.keysym.C-S-Up:   font-size:incglobal
+URxvt.keysym.C-S-Down: font-size:decglobal
 ```
 
 The following functions are supported:

--- a/font-size
+++ b/font-size
@@ -106,25 +106,25 @@ sub on_start
     }
 }
 
-sub on_user_command
+sub on_action
 {
     my ($self, $cmd) = @_;
 
     my $step = $self->{step};
 
-    if ($cmd eq "font-size:increase") {
+    if ($cmd eq "increase") {
         fonts_change_size($self,  $step, 0);
-    } elsif ($cmd eq "font-size:decrease") {
+    } elsif ($cmd eq "decrease") {
         fonts_change_size($self, -$step, 0);
-    } elsif ($cmd eq "font-size:incglobal") {
+    } elsif ($cmd eq "incglobal") {
         fonts_change_size($self,  $step, 1);
-    } elsif ($cmd eq "font-size:decglobal") {
+    } elsif ($cmd eq "decglobal") {
         fonts_change_size($self, -$step, 1);
-    } elsif ($cmd eq "font-size:incsave") {
+    } elsif ($cmd eq "incsave") {
         fonts_change_size($self,  $step, 2);
-    } elsif ($cmd eq "font-size:decsave") {
+    } elsif ($cmd eq "decsave") {
         fonts_change_size($self, -$step, 2);
-    } elsif ($cmd eq "font-size:reset") {
+    } elsif ($cmd eq "reset") {
         fonts_reset($self);
     }
 }


### PR DESCRIPTION
Hey, I'm starting with urxvt and the font-size functionality is a must for me, so I'm trying your plugin.

My `.Xresources` says:
```
! Default fontset
URxvt*font: xft:Inconsolata:pixelsize=20
URxvt.font-size.step: 1

! URxvt*perl-ext-common: string
URxvt*perl-ext-common: default,matcher,font-size

! font size (zoom)
URxvt.keysym.C-Up:     font-size:increase
URxvt.keysym.C-Down:   font-size:decrease
```

I think the function is being called. Using `URXVT_PERL_VERBOSITY=10 urxvt -pe font-size` I got:
```
urxvt: ACTION (urxvt::term=HASH(0x1fa8bf8), font-size, increase, 0, a)
urxvt: ACTION (urxvt::term=HASH(0x1fa8bf8), font-size, decrease, 0, b
```

I've tested with the command `echo -e "\033]710;xft:Inconsolata:pixelsize=22\033\\"` and it works.

Thanks.