### PR TITLE
Add xrdb update command to README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -40,6 +40,11 @@ URxvt.keysym.C-S-Down: font-size:decglobal
 URxvt.keysym.C-equal:  font-size:reset
 URxvt.keysym.C-slash:  font-size:show
 ```
+Then load your new `~/.Xresources` to see the changes in the next terminal you open:
+
+```
+$ xrdb -merge ~/.Xresources
+```
 
 Note that for urxvt versions older than 9.21 the resources have to look like this:
 


### PR DESCRIPTION
This change adds the suggestion to run `xrdb -merge ~/.Xresources` after the keybindings section in the README.md.
I was able to dig this up from my history but others might not be aware of this.