### PR TITLE
Fix usage of readlink to find Xresources

### DIFF
--- a/font-size
+++ b/font-size
@@ -212,8 +212,13 @@ sub fonts_change_size
 
     if ($save > 1) {
         # write the new values back to the file
-        my $xresources = readlink $ENV{"HOME"} . "/.Xresources";
-        system("xrdb -edit " . $xresources);
+        my $xresources = $ENV{"HOME"} . "/.Xresources";
+        my $readlinked = readlink $xresources;
+        if ($readlinked) {
+            system("xrdb -edit " . $readlinked);
+        } else {
+            system("xrdb -edit " . $xresources);
+        }
     }
 }
 


### PR DESCRIPTION
This is the first bit of Perl I've ever written.

I was getting a warning and subsequent error:

```
Use of uninitialized value $xresources in concatenation (.) or string at /home/sgreenup/.urxvt/ext/font-size line 217.
xrdb: -edit requires an argument
usage:  xrdb [-options ...] [filename]

where options include:
 -help               print this help message
 -version            print the program version
 -display host:dpy   display to use
 -all                do all resources [default]
 -global             do screen-independent resources
 -screen             do screen-specific resources for one screen
 -screens            do screen-specific resources for all screens
 -n                  show but don't do changes
 -cpp filename       preprocessor to use [/usr/bin/cpp]
 -nocpp              do not use a preprocessor
 -E                  show preprocessor command & processed input file
 -query              query resources
 -load               load resources from file [default]
 -override           add in resources from file
 -merge              merge resources from file & sort
 -edit filename      edit resources into file
 -backup string      backup suffix for -edit [.bak]
 -symbols            show preprocessor symbols
 -remove             remove resources
 -retain             avoid server reset (avoid using this)
 -quiet              don't warn about duplicates
 -Dname[=value], -Uname, -Idirectory    passed to preprocessor

A - or no input filename represents stdin.
```

My `~/.Xresources` are not symbolically linked, I think that causes `readlink` to return nothing? Or undefined? Which resulted in this error. I've updated what I think is a fix.